### PR TITLE
protobuf-c.c, protoc-c: Remove leading underscores

### DIFF
--- a/protobuf-c/protobuf-c.c
+++ b/protobuf-c/protobuf-c.c
@@ -2095,9 +2095,9 @@ parse_tag_and_wiretype(size_t len,
 
 /* sizeof(ScannedMember) must be <= (1UL<<BOUND_SIZEOF_SCANNED_MEMBER_LOG2) */
 #define BOUND_SIZEOF_SCANNED_MEMBER_LOG2 5
-typedef struct _ScannedMember ScannedMember;
+typedef struct ScannedMember ScannedMember;
 /** Field as it's being read. */
-struct _ScannedMember {
+struct ScannedMember {
 	uint32_t tag;              /**< Field tag. */
 	uint8_t wire_type;         /**< Field type. */
 	uint8_t length_prefix_len; /**< Prefix length. */

--- a/protoc-c/c_message.cc
+++ b/protoc-c/c_message.cc
@@ -111,7 +111,7 @@ MessageGenerator::~MessageGenerator() {}
 
 void MessageGenerator::
 GenerateStructTypedef(io::Printer* printer) {
-  printer->Print("typedef struct _$classname$ $classname$;\n",
+  printer->Print("typedef struct $classname$ $classname$;\n",
                  "classname", FullNameToC(descriptor_->full_name()));
 
   for (int i = 0; i < descriptor_->nested_type_count(); i++) {
@@ -179,7 +179,7 @@ GenerateStructDefinition(io::Printer* printer) {
   PrintComment (printer, msgSourceLoc.leading_comments);
 
   printer->Print(vars,
-    "struct $dllexport$ _$classname$\n"
+    "struct $dllexport$ $classname$\n"
     "{\n"
     "  ProtobufCMessage base;\n");
 

--- a/protoc-c/c_service.cc
+++ b/protoc-c/c_service.cc
@@ -98,8 +98,8 @@ void ServiceGenerator::GenerateMainHFile(io::Printer* printer)
 void ServiceGenerator::GenerateVfuncs(io::Printer* printer)
 {
   printer->Print(vars_,
-		 "typedef struct _$cname$_Service $cname$_Service;\n"
-		 "struct _$cname$_Service\n"
+		 "typedef struct $cname$_Service $cname$_Service;\n"
+		 "struct $cname$_Service\n"
 		 "{\n"
 		 "  ProtobufCService base;\n");
   for (int i = 0; i < descriptor_->method_count(); i++) {


### PR DESCRIPTION
Fixes #188.

Implements suggested fix from the issue:
The struct tag namespace is different from the type namespace. Use the
same symbol names (i.e. without leading underscores) in every namespace.